### PR TITLE
Apply new dark blue theme

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Page Not Found - 2FP Open Tools</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="style.css" />
   <script>
     // Redirect to the main site
     window.location.href = '/';

--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
       }
     }
   </script>
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css" />
+  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/dark.css" />
+  <link rel="stylesheet" href="style.css" />
   <style>
     .app-name-link img {
       max-height: 40px;

--- a/style.css
+++ b/style.css
@@ -1,0 +1,30 @@
+:root {
+  --theme-color: #1e90ff;
+}
+
+body {
+  background-color: #0b1d29;
+  color: #ffffff;
+}
+
+.sidebar {
+  background-color: #000000;
+}
+
+.markdown-section {
+  color: #ffffff;
+}
+
+.markdown-section a {
+  color: var(--theme-color);
+}
+
+.search input {
+  background-color: #000000;
+  color: #ffffff;
+  border-color: var(--theme-color);
+}
+
+.app-nav {
+  background-color: #000000;
+}


### PR DESCRIPTION
## Summary
- switch docsify theme to dark
- add custom CSS for blue/black scheme
- apply style to 404 page

## Testing
- `python3 -m py_compile generate_sidebar.py`

------
https://chatgpt.com/codex/tasks/task_e_688b83afa5d0832eb3e73a4c70ea63ae